### PR TITLE
FEAT: added support for loading NaN (1.#NaN) and Infinite (1.#INF) values and using them in decimal computations

### DIFF
--- a/make/make-settings.r
+++ b/make/make-settings.r
@@ -12,4 +12,5 @@ Defines: [
 	USE_PNG_CODEC
 	USE_GIF_CODEC
 	USE_JPG_CODEC
+	;USE_NO_INFINITY ;-- use when you don't want to support IEEE infinity
 ]

--- a/src/core/f-dtoa.c
+++ b/src/core/f-dtoa.c
@@ -3761,12 +3761,13 @@ dtoa
 #endif
 		{
 		/* Infinity or NaN */
-		*decpt = 9999;
+		*decpt = 1;
 #ifdef IEEE_Arith
 		if (!word1(&u) && !(word0(&u) & 0xfffff))
-			return nrv_alloc("Infinity", rve, 8);
+			return nrv_alloc("1#INF", rve, 5);
 #endif
-		return nrv_alloc("NaN", rve, 3);
+		*sign = 0; //pretend that all NaNs are positive
+		return nrv_alloc("1#NaN", rve, 5);
 		}
 #endif
 #ifdef IBM

--- a/src/core/l-scan.c
+++ b/src/core/l-scan.c
@@ -957,6 +957,25 @@
 				if (cp[0] == '2' && cp[1] == '#' && cp[2] == '{')
 					{cp++; goto pound;} // very rare
 			}
+
+#ifndef USE_NO_INFINITY
+			if (Skip_To_Char(cp, scan_state->end, 'x')) return TOKEN_PAIR;
+			if (
+				cp[0] == '1' && cp[1] == '.'  && cp[2] == '#'
+				) {
+				if ((  (cp[3] == 'I' || cp[3] == 'i')
+					&& (cp[4] == 'N' || cp[4] == 'n')
+					&& (cp[5] == 'F' || cp[5] == 'f')
+					) || (
+					   (cp[3] == 'N' || cp[3] == 'n')
+					&& (cp[4] == 'a' || cp[4] == 'A')
+					&& (cp[5] == 'N' || cp[5] == 'n')
+				)) {
+					return TOKEN_DECIMAL;
+				}
+			}
+#endif // !USE_NO_INFINITY
+
 			return -TOKEN_INTEGER;
 		}
 		if (HAS_LEX_FLAG(flags, LEX_SPECIAL_COLON)) return TOKEN_TIME;  /* 12:34 */

--- a/src/core/t-decimal.c
+++ b/src/core/t-decimal.c
@@ -95,6 +95,10 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 	union {REBDEC d; REBI64 i;} ua, ub;
 	REBI64 int_diff;
 
+#ifndef USE_NO_INFINITY
+	if(isnan(a) || isnan(b)) return FALSE;
+#endif // !USE_NO_INFINITY
+
 	ua.d = a;
 	ub.d = b;
 
@@ -287,7 +291,9 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 
 			case A_DIVIDE:
 			case A_REMAINDER:
+#ifdef USE_NO_INFINITY
 				if (d2 == 0.0) Trap0(RE_ZERO_DIVIDE);
+#endif
 				if (action == A_DIVIDE) d1 /= d2;
 				else d1 = fmod(d1, d2);
 				goto setDec;
@@ -460,7 +466,9 @@ REBOOL almost_equal(REBDEC a, REBDEC b, REBCNT max_diff) {
 	Trap_Action(VAL_TYPE(val), action);
 
 setDec:
+#ifdef USE_NO_INFINITY
 	if (!FINITE(d1)) Trap0(RE_OVERFLOW);
+#endif
 #ifdef not_required
 	if (type == REB_PERCENT) {
 		// Keep percent in smaller range (not to use e notation).


### PR DESCRIPTION
This feature is optional and can be turned of by using USE_NO_INFINITY compilation define.

Here are some examples:
```
>> inf: 1e308 + 1e308
== 1.#INF
>> 1 / inf
== 0.0
>> 1 < inf
== true
>> negate inf
== -1.#INF
>> 1.0 / 0
== 1.#INF
>> arctangent inf
== 90.0
>> 1.#INF - 1.#INF
== 1.#NaN
>> to-binary 1.#NaN
== #{7FF8000000000000}
>> to-binary -1.#NaN
== #{FFF8000000000000}
>> 1.#NaN = 1.#NaN
== false
>> pair: 1x1.#INF
== 1x1.#INF
>> pair/y
== 1.#INF
```