### PR TITLE
Add OpenBSD support

### DIFF
--- a/make/pre-make.r3
+++ b/make/pre-make.r3
@@ -156,6 +156,7 @@ os:  any [
 		Macintosh: macos
 		Windows:   windows
 		Linux:     linux
+		OpenBSD:   openbsd
 	) platform	
 ]
 sys: any [
@@ -167,6 +168,7 @@ sys: any [
 		ios:     darwin
 		windows: win32
 		linux:   linux
+		openbsd: openbsd
 	) os	
 ]
 abi: any [

--- a/make/rebol3.nest
+++ b/make/rebol3.nest
@@ -39,6 +39,12 @@ target-linux: [
 	vendor:   pc
 	compiler: gcc
 ]
+target-openbsd: [
+	os:       openbsd
+	sys:      openbsd
+	vendor:   unknown
+	compiler: clang
+]
 
 core-files: [
 	%core/a-constants.c
@@ -380,6 +386,12 @@ include-image-codecs: [
 	#if MacOS? [
 		:include-image-os-codec
 	]
+	#if OpenBSD? [
+		:include-native-bmp-codec
+		:include-native-png-codec
+		:include-native-jpg-codec
+		:include-native-gif-codec
+	]
 	:include-native-qoi-codec
 	mezz-lib-files: %mezz/codec-image-ext.reb ; png/size? function and similar
 ]
@@ -417,12 +429,24 @@ include-midi: [
 	#if Linux? [
 		; there is no support yet
 	]
+	#if OpenBSD? [
+		; there is no support yet
+	]
 ]
 
 ;- native utilities:                                                            
 include-bincode:    [core-files: %core/u-bincode.c]
 include-dialecting: [core-files: %core/u-dialect.c config: INCLUDE_DELECT]
-include-iconv:      [core-files: %core/u-iconv.c #if macOS? [library: %iconv]]
+include-iconv: [
+	core-files: %core/u-iconv.c
+	#if macOS? [
+		library: %iconv
+	]
+	#if OpenBSD? [
+		library: %iconv
+		lflag: "-L/usr/local/lib"
+	]
+]
 
 ;- native cryptography:                                                         
 include-cryptography: [
@@ -662,6 +686,11 @@ common: [
 		library: %m
 		defines: ENDIAN_LITTLE
 	]
+	#if OpenBSD? [
+		library: %m
+		defines: ENDIAN_LITTLE
+		cflags:  "-I/usr/local/include"
+	]
 ]
 
 common-host: [
@@ -676,6 +705,9 @@ common-host: [
 	#if Linux? [
 	;	flag: -fvisibility=hidden
 		flag: -fPIC       ; position independent (used for libs)
+	]
+	#if OpenBSD? [
+		flag: -fPIC	; position independent (used for libs)
 	]
 ]
 
@@ -696,6 +728,9 @@ arch-x64: [
 		defines: TO_OSX_X64
 		defines: __LP64__ ; same like LLP64, but long (integer) has 64 bits instead of 32
 	] 
+	#if OpenBSD? [
+		defines: TO_OPENBSD
+	]
 ]
 arch-x86: [
 	arch: x86
@@ -706,6 +741,9 @@ arch-x86: [
 	#if Windows? [
 		resource-options: "--target=pe-i386"
 		defines: TO_WIN32
+	]
+	#if OpenBSD? [
+		defines: TO_OPENBSD
 	]
 ]
 arch-arm64: [
@@ -932,21 +970,78 @@ eggs: [
 			:make-x64-host
 		]
 	]
+	#if OpenBSD? [
+		"Rebol/Base openbsd-x64" [
+			name:   %rebol3-base-openbsd-x64
+			:target-openbsd
+			:make-x64-exe
+		]
+		"Rebol/Core openbsd-x64" [
+			name:   %rebol3-core-openbsd-x64
+			:target-openbsd
+			:include-rebol-core
+			:make-x64-exe
+		]
+		"Rebol/Bulk openbsd-x64" [
+			name:   %rebol3-bulk-openbsd-x64
+			:target-openbsd
+			:include-rebol-bulk
+			:make-x64-exe
+		]
+		"Rebol/Bulk openbsd-arm64" [
+			name:   %rebol3-bulk-openbsd-arm64
+			:target-openbsd
+			:include-rebol-bulk
+			:make-arm64-exe
+		]
+
+		"Rebol/Core openbsd-x64 shared library" [
+			name:   %lib-rebol3-core-openbsd-x64
+			:target-openbsd
+			:include-rebol-core
+			:make-x64-dll
+		]
+		"Rebol/Core openbsd-x64 host application" [
+			name:   %host-core-openbsd-x64
+			shared: %lib-rebol3-core-openbsd-x64
+			:target-openbsd
+			:include-rebol-core
+			:make-x64-host
+		]
+	]
 	"Test extension 32bit" [
 		name:  %test-x86.rebx
 		files: only %tests/extension/test.c
 		:arch-x86
 		compiler: gcc
 		flags: [-O2 shared]
-		#if Linux? [ flag: -fPIC ]
-		#either macOS? [:target-macos][compiler: gcc]
+		#if Linux? [
+			flag: -fPIC
+			compiler: gcc
+		]
+		#if MacOS? [
+			:target-macos
+		]
+		#if OpenBSD? [
+			flag: -fPIC
+			:target-openbsd
+		]
 	]
 	"Test extension 64bit" [
 		name:  %test-x64.rebx
 		files: only %tests/extension/test.c
 		:arch-x64
 		flags: [-O2 shared]
-		#if Linux? [ flag: -fPIC ]
-		#either macOS? [:target-macos][compiler: gcc]
+		#if Linux? [
+			flag: -fPIC
+			compiler: gcc
+		]
+		#if MacOS? [
+			:target-macos
+		]
+		#if OpenBSD? [
+			flag: -fPIC
+			:target-openbsd
+		]
 	]
 ]

--- a/make/rebol3.nest
+++ b/make/rebol3.nest
@@ -988,12 +988,6 @@ eggs: [
 			:include-rebol-bulk
 			:make-x64-exe
 		]
-		"Rebol/Bulk openbsd-arm64" [
-			name:   %rebol3-bulk-openbsd-arm64
-			:target-openbsd
-			:include-rebol-bulk
-			:make-arm64-exe
-		]
 
 		"Rebol/Core openbsd-x64 shared library" [
 			name:   %lib-rebol3-core-openbsd-x64

--- a/make/rebol3.nest
+++ b/make/rebol3.nest
@@ -444,6 +444,7 @@ include-iconv: [
 	]
 	#if OpenBSD? [
 		library: %iconv
+		cflags:  "-I/usr/local/include"
 		lflag: "-L/usr/local/lib"
 	]
 ]
@@ -689,7 +690,6 @@ common: [
 	#if OpenBSD? [
 		library: %m
 		defines: ENDIAN_LITTLE
-		cflags:  "-I/usr/local/include"
 	]
 ]
 

--- a/src/core/u-rsa.c
+++ b/src/core/u-rsa.c
@@ -43,6 +43,8 @@
 
 #if defined(TO_OSX_X64) || defined(TO_OSXI) || defined(TO_OSX)
 	#include <sys/malloc.h>
+#elif defined(TO_OPENBSD)
+	/* malloc(3) is inside stdlib.h */
 #else
 	#include <malloc.h>
 #endif

--- a/src/include/reb-config.h
+++ b/src/include/reb-config.h
@@ -210,10 +210,9 @@ These are now obsolete (as of A107) and should be removed:
 #define USE_SETENV 
 #endif
 
-#ifdef TO_OBSD					// OpenBSD
+#ifdef TO_OPENBSD				// OpenBSD
 #undef INCLUDE_MIDI_DEVICE      // Not implemented!
-#define COPY_STR(d,s,m) strlcpy(d,s,m)
-#define JOIN_STR(d,s,m) strlcat(d,s,m)
+#define USE_SETENV 
 #endif
 
 #ifdef TO_AMIGA					// Target for OS4


### PR DESCRIPTION
Some notes:

- `__LP64__` define
  it shouldn't be need : the compiler take care of that itself

- `system/platform`
  it seems the value used isn't from source files, but from the rebol interpreter used when building.
  I had to patch `src/mezz/sys-start.reb` to have "OpenBSD" once, and next it is fine.

- no proud of hard coding `ENDIAN_LITTLE` in `common`: not all archs supported by OpenBSD are little endian.
but it seems there is no simple portable way to detect it in C code (maybe look at [protobuf endian detection as example](https://github.com/protocolbuffers/protobuf/blob/b17c8ca979c40987a6947be2fa7090e6c5bac895/src/google/protobuf/stubs/port.h#L60-L78))

- all eggs are not tested for now:
  - [x] Rebol/Base openbsd-x64
  - [x] Rebol/Core openbsd-x64
  - [x] Rebol/Bulk openbsd-x64
  - [ ] Rebol/Bulk openbsd-arm64
  - [x] Rebol/Core openbsd-x64 shared library
  - [x] Rebol/Core openbsd-x64 host application
  - [ ] Test extension 32bit
  - [x] Test extension 64bit
