### PR TITLE
Document FORMAT-DATE-TIME

### DIFF
--- a/src/mezz/mezz-series.reb
+++ b/src/mezz/mezz-series.reb
@@ -489,6 +489,7 @@ format: function [
 ]
 
 format-date-time: function/with [
+	"replaces a subset of ISO 8601 abbreviations such as yyyy-MM-dd hh:mm:ss"
 	value [date! time!]
 	rule  [string! tag!]
 ][


### PR DESCRIPTION
I assume the inspiration was ISO 8601, if there's another standard that this was based on that can be mentioned instead.