### PR TITLE
Add error message to CALL/INFO

### DIFF
--- a/src/core/n-io.c
+++ b/src/core/n-io.c
@@ -899,6 +899,15 @@ chk_neg:
 			SET_INTEGER(val, exit_code);
 		}
 
+		// based on f-stubs Make_OS_Error()
+		if (r != 0) {
+			REBCHR str[100];
+			OS_FORM_ERROR(r, str, 100);
+
+			val = Append_Frame(obj, NULL, SYM_ERROR);
+			SET_STRING(val, Copy_OS_Str(str, (REBINT)LEN_STR(str)));
+		}
+
 		SET_OBJECT(D_RET, obj);
 		return R_RET;
 	}


### PR DESCRIPTION
Previously `CALL/INFO` would give no indication of what the error was or even if there was one beyond setting the PID to zero. Now it includes the error message when encountering an error.

I pulled the code from `f-stubs.c`'s `Make_OS_Error()` function. I would prefer to convert the `REBVAL` returned by `Make_OS_Error()` into a `REBSER` instead but I wasn't sure how to do so with the macro system.

Consider this a proof of concept if there is a better way.